### PR TITLE
fix/image routing issues and styling discrepancies 

### DIFF
--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -1,0 +1,13 @@
+[browser]
+# Disable streamlit collecting user statistics, https://streamlit.io/privacy-policy
+gatherUsageStats = false
+
+[client]
+# Minimal appearance of user interface
+toolbarMode = "minimal"
+
+[theme]
+primaryColor = "#9A928F"
+backgroundColor = "#ffffff"
+secondaryBackgroundColor = "#e0dedd"
+textColor = "#000000"

--- a/code/interview.py
+++ b/code/interview.py
@@ -26,7 +26,9 @@ else:
 # Set page title and icon
 st.set_page_config(page_title="Interview", page_icon=config.AVATAR_INTERVIEWER)
 
-st.sidebar.image("code/assets/GATSBY_Logo_RGB.png", width=200)
+# Use a dynamic path that works both locally and in deployment
+image_path = "assets/GATSBY_Logo_RGB.png" if os.path.exists("assets/GATSBY_Logo_RGB.png") else "code/assets/GATSBY_Logo_RGB.png"
+st.sidebar.image(image_path, width=200)
 
 
 # Test MongoDB connection (temporary for verification)


### PR DESCRIPTION
This should fix the styling issues. The streamlit deployment seems to look for a `.streamlit/config.toml` file in the root folder, whereas when running the project locally, the same file needs to be inside the `code` folder. 

This is a bug that seems to have originated from the strange folder structure of the tool we originally cloned our repo from.

I think should be added to issues rather than fixed as a priority.

I also added dynamic routing for the Gatsby logo image path, as this is encountering similar issues.