### PR TITLE
Summary job categorisation

### DIFF
--- a/code/dashboard/pages/View_Staff_Transcripts.py
+++ b/code/dashboard/pages/View_Staff_Transcripts.py
@@ -8,7 +8,8 @@ import streamlit as st
 # Add parent directory to path so we can import from parent modules
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-# Import login functionality from the centralized login module
+# Import database functions
+from database import get_staff_roles
 
 # Initialize the admin page with login
 if not setup_admin_page("View Staff Transcripts | Gatsby AI Interview"):
@@ -20,8 +21,12 @@ st.header("Staff Transcripts")
 # Initialize session state for refresh counter
 initialise_session_state()
 
+# Add role filter dropdown
+staff_roles = get_staff_roles()
+selected_role = st.selectbox("Filter by role:", staff_roles)
+
 # Create container for interviews
 interview_container = st.container()
 
-# Render the interviews
-render_interviews(interview_container, "Staff")
+# Render the interviews with role filter
+render_interviews(interview_container, "Staff", role=selected_role)

--- a/code/dashboard/transcript_utils.py
+++ b/code/dashboard/transcript_utils.py
@@ -109,17 +109,18 @@ def render_analysis_date(analyzed_at, title="Analysis"):
     return f"### {title}"
 
 
-def render_interviews(container, interview_type):
+def render_interviews(container, interview_type, role=None):
     """Render interviews with their analyses.
 
     Args:
         container: Streamlit container to render within
         interview_type: Type of interview ("Student" or "Staff")
+        role: Optional role filter for Staff interviews
     """
     with container:
         try:
             with st.spinner(f"Loading {interview_type.lower()} interviews..."):
-                interviews = get_interviews(type=interview_type)
+                interviews = get_interviews(type=interview_type, role=role)
             if interviews:
                 for interview in interviews:
                     username = interview.get("username", "Unknown")
@@ -136,6 +137,10 @@ def render_interviews(container, interview_type):
                                 interview, "age_group", "Age Group", "text")
                             safe_render_field(
                                 interview, "gender", "Gender", "text")
+                            # Display role for Staff interviews
+                            if interview_type == "Staff":
+                                safe_render_field(
+                                    interview, "role", "Role", "text")
                             render_time_data(interview.get("time_data"))
                             completed = interview.get("completed")
                             if completed is not None:


### PR DESCRIPTION
  - Enhanced database query functionality: Added ability to filter staff interviews by their role (principal,
  teacher, office) through the database layer, making role-based analysis more efficient
  - Added dynamic role dropdown to Staff Transcripts page: Users can now easily filter the view to show only
  interviews from specific staff roles, providing better organization of interview data
  - Improved staff transcript display: Staff role information is now clearly shown in the interview details section,
  making it easier to identify the interviewee's position
  - Implemented role-specific summary generation: Added filtering capability to the Summarise Transcripts page,
  allowing generation of targeted summaries for specific staff roles (e.g., teacher-only or principal-only summaries)
  - Enhanced user feedback: Success messages, summary headers, and download filenames now include role information
  when filtering is applied, providing clearer context for filtered data
  - Created a more targeted analysis workflow: Users can now generate separate summaries for different staff roles,
  enabling more nuanced insights about how different staff categories perceive AI in education
